### PR TITLE
Add `attachment_taxonomies_base_path_relative` filter.

### DIFF
--- a/attachment-taxonomies.php
+++ b/attachment-taxonomies.php
@@ -103,7 +103,7 @@ final class Attachment_Taxonomies {
 		$mu_plugin_dir = wp_normalize_path( WPMU_PLUGIN_DIR );
 		if ( preg_match( '#^' . preg_quote( $mu_plugin_dir, '#' ) . '/#', $file ) ) {
 			$this->is_mu_plugin = true;
-			$this->base_path_relative = 'attachment-taxonomies/';
+			$this->base_path_relative = apply_filters( 'attachment_taxonomies_base_path_relative', 'attachment-taxonomies/' );
 			add_action( 'muplugins_loaded', array( $this, 'bootstrap' ), 1 );
 		} else {
 			add_action( 'plugins_loaded', array( $this, 'bootstrap' ), 1 );


### PR DESCRIPTION
**What**
Filter the manual `Attachment_Taxonomies->base_path_relative` var from outside the plugin.

**Why**
Useful when custom autoloaders within MU plugins, [hm-base](https://github.com/humanmade/hm-base/blob/master/content/plugins-mu/loader.php) in particular.

**Usage**
`add_filter( 'attachment_taxonomies_base_path_relative', '__return_empty_string' );`

Fixes #2.
